### PR TITLE
Updated the python example for Create Steps API with keywords and properties

### DIFF
--- a/Python Examples/TestMonitor/CreateResultsAndSteps/create_results_and_steps.py
+++ b/Python Examples/TestMonitor/CreateResultsAndSteps/create_results_and_steps.py
@@ -197,7 +197,9 @@ def create_child_steps(parent_step: Dict, result_id: str, current: float, low_li
                 parameters = test_parameters, 
                 status = status,
                 result_id = result_id,
-                parent_id = parent_step["stepId"]
+                parent_id = parent_step["stepId"],
+                keywords= ["keyword1", "keyword2"],
+                properties={"key1": "value1", "key2": "value2"}
             )
             # Create the step on the SystemLink enterprise.
             response = test_data_manager_client.create_steps(steps=[measure_power_output_step_data])

--- a/Python Examples/TestMonitor/test_data_manager_client.py
+++ b/Python Examples/TestMonitor/test_data_manager_client.py
@@ -84,6 +84,8 @@ def create_test_step(
     outputs: List[Dict] = None,
     parameters: Dict = None,
     status: Dict = None,
+    keywords: List[str] = None,
+    properties: Dict[str, str] = None,
 ) -> Dict:
     """
     Creates the step data and
@@ -93,7 +95,9 @@ def create_test_step(
     :param inputs: The test step's input values.
     :param outputs: The test step's output values.
     :param parameters: The measurement parameters.
-    :param status: The test step's status
+    :param status: The test step's status.
+    :param keywords: The test steps's keywords.
+    :param properties: The test steps's properties.
     :return: The step data used to create a test step.
     """
     step_status = status if status else {
@@ -114,7 +118,9 @@ def create_test_step(
         "stepType": step_type,
         "totalTimeInSeconds": random.uniform(0, 1) * 10,
         "inputs": inputs,
-        "outputs": outputs
+        "outputs": outputs,
+        "keywords": keywords,
+        "properties": properties
     }
 
     return step_data


### PR DESCRIPTION
**Justification**
As a part of this [Feature 2092223](https://ni.visualstudio.com/DevCentral/_workitems/edit/2092223): Add keywords and properties to steps, we have added two new properties (`keywords` and `properties`) to steps and we have to update the examples accordingly.

**Implementation**
Updated the `CreateResultsAndSteps` Python example with `keywords` and `properties` for steps.

**Testing**
Manual testing completed