### PR TITLE
Update auto schedule and automate test plans sample scripts to include schedule page links in results

### DIFF
--- a/Test Plan Automations Examples/Update_Testplans_With_Template_Sample_Script.ipynb
+++ b/Test Plan Automations Examples/Update_Testplans_With_Template_Sample_Script.ipynb
@@ -385,7 +385,7 @@
    "source": [
     "## Actions and output\n",
     "\n",
-    "Validates the inputs, manages the execution flow, and prints the script output and sends the output to the Execution Results page via Scrapbook."
+    "Validates the inputs, manages the execution flow, and prints the script output and sends the output to the Execution Results page via Scrapbook where the output includes the total number of thet plans processed, the updated and not updated test plans,  and provides a link to the schedule page where the updated test plans are highlighted."
    ]
   },
   {
@@ -403,6 +403,7 @@
    "source": [
     "updated_test_plan_ids = []\n",
     "failed_test_plan_ids = []\n",
+    "schedule_route = \"labmanagement/schedule\"\n",
     "\n",
     "if len(test_plan_ids) == 0:\n",
     "    print(\"Required atleast one test plan id\")\n",
@@ -434,7 +435,13 @@
     "        # Executions page output\n",
     "        sb.glue(\"Total test plans:\", len(test_plan_ids))\n",
     "        sb.glue(\"Test plans updated:\", ', '.join(updated_test_plan_ids) if updated_test_plan_ids else \"--\")\n",
-    "        sb.glue(\"Test plans not updated:\", ', '.join(failed_test_plan_ids) if failed_test_plan_ids else \"--\")"
+    "        sb.glue(\"Test plans not updated:\", ', '.join(failed_test_plan_ids) if failed_test_plan_ids else \"--\")\n",
+    "\n",
+    "        if updated_test_plan_ids:\n",
+    "            sb.glue(\n",
+    "                \"View updated test plans in schedule page\",\n",
+    "                f\"<a href=\\\"../../{schedule_route}?test-plans={','.join(updated_test_plan_ids)}\\\">link</a>\"\n",
+    "            )"
    ]
   },
   {

--- a/Test Plan Automations Examples/Update_Testplans_With_Template_Sample_Script.ipynb
+++ b/Test Plan Automations Examples/Update_Testplans_With_Template_Sample_Script.ipynb
@@ -445,7 +445,7 @@
     "        if updated_test_plan_ids:\n",
     "            sb.glue(\n",
     "                \"View updated test plans in schedule page\",\n",
-    "                f\"<a href=\\\"../../{schedule_route}?test-plans={','.join(updated_test_plan_ids)}\\\">link</a>\"\n",
+    "                f\"<a href=\\\"../../{schedule_route}?test-plans={','.join(updated_test_plan_ids)}\\\">Schedule View</a>\"\n",
     "            )"
    ]
   },

--- a/Test Plan Automations Examples/Update_Testplans_With_Template_Sample_Script.ipynb
+++ b/Test Plan Automations Examples/Update_Testplans_With_Template_Sample_Script.ipynb
@@ -385,7 +385,12 @@
    "source": [
     "## Actions and output\n",
     "\n",
-    "Validates the inputs, manages the execution flow, and prints the script output and sends the output to the Execution Results page via Scrapbook where the output includes the total number of thet plans processed, the updated and not updated test plans,  and provides a link to the schedule page where the updated test plans are highlighted."
+    "Validates the inputs, manages the execution flow, prints the script output, and sends the output to the Execution Results page via Scrapbook. The output includes:\n",
+    "\n",
+    "1. The total number of test plans processed.\n",
+    "1. A list of updated test plan IDs.\n",
+    "1. A list of test plan IDs that were not updated.\n",
+    "1. A link to the schedule page. The test plan IDs of updated test plans included in this URL will be highlighted on the schedule page, enabling easy differentiation of updated test plans from others."
    ]
   },
   {

--- a/Test Plan Scheduler Examples/Auto_Schedule_Testplans_Sample_Script.ipynb
+++ b/Test Plan Scheduler Examples/Auto_Schedule_Testplans_Sample_Script.ipynb
@@ -204,6 +204,9 @@
     "# Default estimated duration of test plan = 1 day\"\n",
     "DEFAULT_TEST_PLAN_DURATION_IN_SECONDS =  24 * 60 * 60\n",
     "\n",
+    "# Route for the schedule page in SystemLink\n",
+    "SCHEDULE_ROUTE = \"labmanagement/schedule\"\n",
+    "\n",
     "_current_time = datetime.now(timezone.utc)\n",
     "_end_time_six_months = _current_time + timedelta(days = 182)\n",
     "\n",
@@ -1087,7 +1090,7 @@
    "source": [
     "## Executions page output\n",
     "\n",
-    "Send the output to the Execution Results page via Scrapbook."
+    "The output is sent to the Execution Results page using Scrapbook. This includes details such as the total number of test plans processed, the scheduled and unscheduled test plans, and a link to the schedule page where the scheduled test plans are highlighted."
    ]
   },
   {
@@ -1104,7 +1107,14 @@
     "if len(unscheduled_test_plans) == 0:\n",
     "    sb.glue(\"Unscheduled test plans\",  \"-\")\n",
     "else:\n",
-    "    sb.glue(\"Unscheduled test plans\",  unscheduled_test_plans)"
+    "    sb.glue(\"Unscheduled test plans\",  unscheduled_test_plans)\n",
+    "\n",
+    "if scheduled_test_plans:\n",
+    "    scheduled_test_plan_ids = ','.join(scheduled_test_plans)\n",
+    "    sb.glue(\n",
+    "        \"View scheduled test plans in schedule page\",\n",
+    "        f\"<a href=\\\"../../{SCHEDULE_ROUTE}?test-plans={scheduled_test_plan_ids}\\\">link</a>\"\n",
+    "    )"
    ]
   },
   {

--- a/Test Plan Scheduler Examples/Auto_Schedule_Testplans_Sample_Script.ipynb
+++ b/Test Plan Scheduler Examples/Auto_Schedule_Testplans_Sample_Script.ipynb
@@ -1090,7 +1090,12 @@
    "source": [
     "## Executions page output\n",
     "\n",
-    "The output is sent to the Execution Results page using Scrapbook. This includes details such as the total number of test plans processed, the scheduled and unscheduled test plans, and a link to the schedule page where the scheduled test plans are highlighted."
+    "Send the output to the Execution Results page via Scrapbook. This includes:\n",
+    "\n",
+    "1. The total number of test plans processed.\n",
+    "1. A list of scheduled test plan names.\n",
+    "1. A list of unscheduled test plan names.\n",
+    "1. A link to the schedule page. The test plan IDs of the updated test plans included in this URL will be highlighted on the schedule page, making it easy to differentiate updated test plans from others."
    ]
   },
   {

--- a/Test Plan Scheduler Examples/Auto_Schedule_Testplans_Sample_Script.ipynb
+++ b/Test Plan Scheduler Examples/Auto_Schedule_Testplans_Sample_Script.ipynb
@@ -1118,7 +1118,7 @@
     "    scheduled_test_plan_ids = ','.join(scheduled_test_plans)\n",
     "    sb.glue(\n",
     "        \"View scheduled test plans in schedule page\",\n",
-    "        f\"<a href=\\\"../../{SCHEDULE_ROUTE}?test-plans={scheduled_test_plan_ids}\\\">link</a>\"\n",
+    "        f\"<a href=\\\"../../{SCHEDULE_ROUTE}?test-plans={scheduled_test_plan_ids}\\\">Schedule View</a>\"\n",
     "    )"
    ]
   },


### PR DESCRIPTION
Justification

- This update enhances the auto schedule and automate test plans sample scripts by including schedule page links in the results. It allows users to directly view the scheduled or updated test plans, with highlights for better visibility and tracking.
 
Implementation

- Updated auto schedule and automate test plans sample scripts to include schedule page links in results

Testing

- Manually tested