### PR TITLE
Update auto-schedule sample script to handle API errors and prevent invalid type conversions

### DIFF
--- a/Test Plan Scheduler Examples/Auto_Schedule_Testplans_Sample_Script.ipynb
+++ b/Test Plan Scheduler Examples/Auto_Schedule_Testplans_Sample_Script.ipynb
@@ -43,7 +43,7 @@
    "outputs": [],
    "source": [
     "from datetime import datetime, timedelta, timezone\n",
-    "from typing import Dict, List, Tuple, Any\n",
+    "from typing import Dict, List, Tuple, Any, Optional\n",
     "import scrapbook as sb\n",
     "\n",
     "from nisystemlink.clients.assetmanagement import AssetManagementClient\n",
@@ -267,7 +267,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def get_test_plan(test_plan_to_schedule_id) -> TestPlan:\n",
+    "def get_test_plan(test_plan_to_schedule_id) -> Optional[TestPlan]:\n",
     "    try:\n",
     "        return test_plan_client.get_test_plan(test_plan_to_schedule_id)\n",
     "    except Exception as e:\n",
@@ -930,7 +930,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def fetch_systems_and_fixtures(test_plan) -> tuple:\n",
+    "def fetch_systems_and_fixtures(test_plan) -> Tuple[List[Dict[str, Any]], Dict[str, List[str]]]:\n",
     "    systems = query_systems(test_plan.system_filter)\n",
     "    if systems is []:\n",
     "        return [], {}\n",

--- a/Test Plan Scheduler Examples/Auto_Schedule_Testplans_Sample_Script.ipynb
+++ b/Test Plan Scheduler Examples/Auto_Schedule_Testplans_Sample_Script.ipynb
@@ -49,7 +49,7 @@
     "from nisystemlink.clients.assetmanagement import AssetManagementClient\n",
     "from nisystemlink.clients.assetmanagement.models import (\n",
     "    Asset,\n",
-    "    QueryAssetsRequest,\n",
+    "    QueryAssetsRequest\n",
     ")\n",
     "from nisystemlink.clients.systems import SystemsClient\n",
     "from nisystemlink.clients.systems.models import QuerySystemsRequest\n",
@@ -58,7 +58,7 @@
     "    QueryTestPlansRequest,\n",
     "    ScheduleTestPlansRequest,\n",
     "    ScheduleTestPlanRequest,\n",
-    "    TestPlan,\n",
+    "    TestPlan\n",
     ")"
    ]
   },
@@ -165,7 +165,7 @@
    "outputs": [],
    "source": [
     "# Add the test plan Ids as a list of strings here\n",
-    "test_plan_ids = [] "
+    "test_plan_ids = []"
    ]
   },
   {
@@ -268,7 +268,10 @@
    "outputs": [],
    "source": [
     "def get_test_plan(test_plan_to_schedule_id) -> TestPlan:\n",
-    "    return test_plan_client.get_test_plan(test_plan_to_schedule_id)"
+    "    try:\n",
+    "        return test_plan_client.get_test_plan(test_plan_to_schedule_id)\n",
+    "    except Exception as e:\n",
+    "        return None"
    ]
   },
   {
@@ -294,8 +297,11 @@
     "        filter = system_filter\n",
     "    )\n",
     "\n",
-    "    response = system_client.query_systems(request)\n",
-    "    return response.data"
+    "    try:\n",
+    "        response = system_client.query_systems(request)\n",
+    "        return response.data\n",
+    "    except Exception as e:\n",
+    "        return []"
    ]
   },
   {
@@ -326,8 +332,11 @@
     "        descending = True,\n",
     "    )\n",
     "\n",
-    "    response = asset_client.query_assets(request)\n",
-    "    return response.assets"
+    "    try:\n",
+    "        response = asset_client.query_assets(request)\n",
+    "        return response.assets\n",
+    "    except Exception as e:\n",
+    "        return []"
    ]
   },
   {
@@ -345,10 +354,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def query_test_plans(systems) -> List[TestPlan]:\n",
+    "def query_test_plans(systems) -> Tuple[List[TestPlan], bool]:\n",
     "    system_conditions = [f'systemId == \"{system[\"id\"]}\"' for system in systems]\n",
+    "\n",
+    "    if system_conditions:\n",
+    "        system_ids = f\"({' or '.join(system_conditions)}) and \"\n",
+    "    else:\n",
+    "        system_ids = \"\"\n",
+    "\n",
     "    testplans_filter = (\n",
-    "        f\"({' or '.join(system_conditions)}) and \"\n",
+    "        f\"{system_ids}\"\n",
     "        f\"(plannedStartDateTime <= \\\"{due_date_time}\\\" and \"\n",
     "        f\"estimatedEndDateTime >= \\\"{start_time}\\\")\"\n",
     "    )\n",
@@ -364,7 +379,10 @@
     "            continuation_token = continuation_token\n",
     "        )\n",
     "\n",
-    "        response = test_plan_client.query_test_plans(query_request)\n",
+    "        try:\n",
+    "            response = test_plan_client.query_test_plans(query_request)\n",
+    "        except Exception as e:\n",
+    "            return [], False\n",
     "\n",
     "        if response.test_plans:\n",
     "            all_test_plans.extend(response.test_plans)\n",
@@ -375,7 +393,7 @@
     "        else:\n",
     "            break\n",
     "\n",
-    "    return all_test_plans[:MAX_TEST_PLANS_COUNT]\n"
+    "    return all_test_plans[:MAX_TEST_PLANS_COUNT], True\n"
    ]
   },
   {
@@ -427,9 +445,7 @@
   {
    "cell_type": "markdown",
    "id": "e74a7ab9-107f-4b42-bdfd-acbefe6184f5",
-   "metadata": {
-    "jp-MarkdownHeadingCollapsed": true
-   },
+   "metadata": {},
    "source": [
     "## Algorithm\n",
     "\n",
@@ -524,11 +540,11 @@
     "    current_date_time = datetime.fromisoformat(start_time.replace(\"Z\", \"+00:00\"))\n",
     "    \n",
     "    for system_id, test_plans in system_with_test_plans.items():\n",
-    "        test_plans.sort(key = lambda test_plan: datetime.fromisoformat(test_plan['estimated_end_time'].replace(\"Z\", \"+00:00\")))\n",
+    "        test_plans.sort(key = lambda test_plan: test_plan['estimated_end_time'])\n",
     "\n",
     "        test_plans = [\n",
     "            test_plan for test_plan in test_plans \n",
-    "            if datetime.fromisoformat(test_plan['estimated_end_time'].replace(\"Z\", \"+00:00\")) > current_date_time\n",
+    "            if test_plan['estimated_end_time'] > current_date_time\n",
     "        ]\n",
     "\n",
     "        system_with_test_plans[system_id] = test_plans\n",
@@ -567,16 +583,16 @@
     "\n",
     "    for system_id, occupied_slots in system_with_test_plans.items():\n",
     "        occupied_slots.sort(\n",
-    "            key = lambda occupied_slot: datetime.fromisoformat(occupied_slot['planned_start_time'].replace(\"Z\", \"+00:00\"))\n",
+    "            key = lambda occupied_slot: occupied_slot['planned_start_time']\n",
     "        )\n",
     "        \n",
     "        last_busy_end_time = current_date_time\n",
     "\n",
     "        for slot in occupied_slots:\n",
-    "            start_time = datetime.fromisoformat(slot['planned_start_time'].replace(\"Z\", \"+00:00\"))\n",
-    "            end_time = datetime.fromisoformat(slot['estimated_end_time'].replace(\"Z\", \"+00:00\"))\n",
+    "            slot_start_time = slot['planned_start_time']\n",
+    "            slot_end_time = slot['estimated_end_time']\n",
     "\n",
-    "            if start_time > last_busy_end_time + test_plan_duration:\n",
+    "            if slot_start_time > last_busy_end_time + test_plan_duration:\n",
     "                available_slots.append({\n",
     "                    'system_id': system_id,\n",
     "                    'planned_start_time': last_busy_end_time.isoformat(),\n",
@@ -584,7 +600,7 @@
     "                })\n",
     "                break\n",
     "\n",
-    "            last_busy_end_time = max(last_busy_end_time, end_time)\n",
+    "            last_busy_end_time = max(last_busy_end_time, slot_end_time)\n",
     "\n",
     "        if last_busy_end_time + test_plan_duration < datetime.fromisoformat(due_date_time.replace(\"Z\", \"+00:00\")):\n",
     "            available_slots.append({\n",
@@ -593,7 +609,7 @@
     "                'estimated_end_time': (last_busy_end_time + test_plan_duration).isoformat()\n",
     "            })\n",
     "\n",
-    "    available_slots.sort(key = lambda available_slot: datetime.fromisoformat(available_slot['planned_start_time']))\n",
+    "    available_slots.sort(key = lambda available_slot: available_slot['planned_start_time'])\n",
     "\n",
     "    return available_slots"
    ]
@@ -916,8 +932,8 @@
    "source": [
     "def fetch_systems_and_fixtures(test_plan) -> tuple:\n",
     "    systems = query_systems(test_plan.system_filter)\n",
-    "    if systems is None:\n",
-    "        return None, None\n",
+    "    if systems is []:\n",
+    "        return [], {}\n",
     "    fixtures = query_fixtures(systems)\n",
     "    system_fixtures_map = get_system_fixtures_map(fixtures)\n",
     "    return systems, system_fixtures_map"
@@ -968,10 +984,25 @@
     "    system_with_test_plans = organize_test_plans_by_system(test_plans, systems)\n",
     "    sorted_system_test_plans = sort_and_filter_system_test_plans(system_with_test_plans)\n",
     "    available_slots_in_systems = find_available_slots(sorted_system_test_plans, test_plan_to_schedule)\n",
-    "    earliest_available_slot = get_available_slot(available_slots_in_systems, system_fixtures_map, number_of_fixtures_to_schedule)\n",
-    "    \n",
-    "    fixtureIds = system_fixtures_map.get(earliest_available_slot['system_id'], [])[:number_of_fixtures_to_schedule]\n",
-    "    return schedule_test_plan(test_plan_to_schedule.id, earliest_available_slot, test_plan_to_schedule, fixtureIds)"
+    "    earliest_available_slot = get_available_slot(\n",
+    "        available_slots_in_systems,\n",
+    "        system_fixtures_map,\n",
+    "        number_of_fixtures_to_schedule\n",
+    "    )\n",
+    "\n",
+    "    # Handle case when no slot is available\n",
+    "    if not earliest_available_slot:\n",
+    "        print(\"No available slot found for scheduling.\")\n",
+    "        return False\n",
+    "\n",
+    "    fixture_ids = system_fixtures_map.get(earliest_available_slot['system_id'], [])[:number_of_fixtures_to_schedule]\n",
+    "\n",
+    "    return schedule_test_plan(\n",
+    "        test_plan_to_schedule.id,\n",
+    "        earliest_available_slot,\n",
+    "        test_plan_to_schedule,\n",
+    "        fixture_ids\n",
+    "    )"
    ]
   },
   {
@@ -996,6 +1027,7 @@
     "def process_test_plan(test_plan_id, test_plan_ids) -> None:\n",
     "    test_plan_to_schedule = get_test_plan(test_plan_id)\n",
     "    if test_plan_to_schedule is None:\n",
+    "        unscheduled_test_plans.append(test_plan_id)\n",
     "        return False\n",
     "    \n",
     "    number_of_fixtures_to_schedule = get_number_of_fixtures(test_plan_to_schedule)\n",
@@ -1007,13 +1039,13 @@
     "\n",
     "    # Fetch systems and fixtures\n",
     "    systems, system_fixtures_map = fetch_systems_and_fixtures(test_plan_to_schedule)\n",
-    "    if systems is None:\n",
+    "    if systems is []:\n",
     "        unscheduled_test_plans.append(test_plan_id)\n",
     "        return False\n",
     "\n",
     "    # Query existing test plans\n",
-    "    test_plans = query_test_plans(systems)\n",
-    "    if test_plans is None:\n",
+    "    test_plans, test_plan_received = query_test_plans(systems)\n",
+    "    if test_plan_received is False:\n",
     "        unscheduled_test_plans.append(test_plan_id)\n",
     "        return False\n",
     "\n",


### PR DESCRIPTION
Justification
- The script failed due to API errors caused by invalid data, and it also included unnecessary date-time conversions that weren’t required.

Implementation
- Added try-expect handlings to APIs and removed dateTime conversion.

Testing
- Manually tested