### PR TITLE
Refactor output format of Update Test Plans with Templates script

### DIFF
--- a/Test Plan Automations Examples/Update_Testplans_With_Template_Sample_Script.ipynb
+++ b/Test Plan Automations Examples/Update_Testplans_With_Template_Sample_Script.ipynb
@@ -389,8 +389,7 @@
     "\n",
     "1. The total number of test plans processed.\n",
     "1. A list of updated test plan IDs.\n",
-    "1. A list of test plan IDs that were not updated.\n",
-    "1. A link to the schedule page. The test plan IDs of updated test plans included in this URL will be highlighted on the schedule page, enabling easy differentiation of updated test plans from others."
+    "1. A list of test plan IDs that were not updated."
    ]
   },
   {
@@ -408,7 +407,6 @@
    "source": [
     "updated_test_plan_ids = []\n",
     "failed_test_plan_ids = []\n",
-    "schedule_route = \"labmanagement/schedule\"\n",
     "\n",
     "if len(test_plan_ids) == 0:\n",
     "    print(\"Required atleast one test plan id\")\n",
@@ -440,13 +438,7 @@
     "        # Executions page output\n",
     "        sb.glue(\"Total test plans:\", len(test_plan_ids))\n",
     "        sb.glue(\"Test plans updated:\", ', '.join(updated_test_plan_ids) if updated_test_plan_ids else \"--\")\n",
-    "        sb.glue(\"Test plans not updated:\", ', '.join(failed_test_plan_ids) if failed_test_plan_ids else \"--\")\n",
-    "\n",
-    "        if updated_test_plan_ids:\n",
-    "            sb.glue(\n",
-    "                \"View updated test plans in schedule page\",\n",
-    "                f\"<a href=\\\"../../{schedule_route}?test-plans={','.join(updated_test_plan_ids)}\\\">Schedule View</a>\"\n",
-    "            )"
+    "        sb.glue(\"Test plans not updated:\", ', '.join(failed_test_plan_ids) if failed_test_plan_ids else \"--\")"
    ]
   },
   {


### PR DESCRIPTION
#**Justification: **
- Removed the schedule page link because the “Update Test Plans with Templates” script is focused solely on updating test plans, not scheduling them. Including a scheduling-related link was outside the script’s scope and could create confusion about its purpose.

#**Implementation:**
- Removed the code that generated and displayed the “View updated test plans in schedule page” link.
- No functional changes to the actual test plan update logic.