### PR TITLE
chore: update urllib3 to 2.6

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1457,22 +1457,22 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.5.0"
+version = "2.6.1"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc"},
-    {file = "urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760"},
+    {file = "urllib3-2.6.1-py3-none-any.whl", hash = "sha256:e67d06fe947c36a7ca39f4994b08d73922d40e6cca949907be05efa6fd75110b"},
+    {file = "urllib3-2.6.1.tar.gz", hash = "sha256:5379eb6e1aba4088bae84f8242960017ec8d8e3decf30480b3a1abdaa9671a3f"},
 ]
 
 [package.extras]
-brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)"]
+brotli = ["brotli (>=1.2.0)", "brotlicffi (>=1.2.0.0)"]
 h2 = ["h2 (>=4,<5)"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
-zstd = ["zstandard (>=0.18.0)"]
+zstd = ["backports-zstd (>=1.0.0)"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "e234279f0268c67afa2fc365d78c18d044beaab330068c94605eedf3978026d1"
+content-hash = "9054a301f6f6f2a24df4dda113dcd571334d13ea60757ee8c463af239fb60ffa"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ packages = [
 python = "^3.10"
 nisystemlink-clients = "^2.18.0"
 requests = "^2.32.5"
+urllib3 = "^2.6.0"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
### Justification

This addresses a security concern in urllib3. Details are in https://github.com/ni/systemlink-enterprise-examples/pull/37 which we rejected because the version update was done only in the `.lock` file. 

### Implementation

Bump the version of urllib in the .toml file so that we enforce a good version even if dependencies allow older ones. 

### Testing

Auto-testing on pipeline. 

## Checklist

- [x] I have read and followed the [Contributing Guidelines](../CONTRIBUTING.md)
