### PR TITLE
fix: Duplicate check on pipeline events

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -38,7 +38,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: [build-lint-unit-test]
-    if: github.event_name == github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main')
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main')
     environment:
       name: pypi
       url: https://pypi.org/p/nisystemlink-examples


### PR DESCRIPTION
### Justification

The initial commit for the publish action had an incorrect condition check. 

### Implementation

Fix the condition typo

## Checklist

- [x] I have read and followed the [Contributing Guidelines](../CONTRIBUTING.md)
