### PR TITLE
fix: Bump version properly when running on main

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -62,7 +62,13 @@ jobs:
           pip install python-semantic-release==7.34.6
           git config --global user.name "github-actions"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          semantic-release changelog
           semantic-release version
+        env:
+          GH_TOKEN: ${{secrets.GH_REPO_TOKEN}}
+      - name: Create GitHub Release
+        run: |
+          semantic-release publish --skip-build
         env:
           GH_TOKEN: ${{secrets.GH_REPO_TOKEN}}
       - name: Build package


### PR DESCRIPTION
### Justification

semantic-release wasn't bumping versions properly or creating github releases. This should fix that

### Implementation

manually call `changelog` and `version` with semantic-revision then call `publish`.
We're not using semantic-release to write to pypi because we're using trusted publishing. 

## Checklist

- [ ] I have read and followed the [Contributing Guidelines](../CONTRIBUTING.md)
