### PR TITLE
build: Ignore .NET build output folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 
 # Distribution / packaging
 .Python
+bin/
 build/
 develop-eggs/
 dist/

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ eggs/
 .eggs/
 lib/
 lib64/
+obj/
 parts/
 sdist/
 var/


### PR DESCRIPTION
# Rationale

Today when I open the entire repo in VSCode with .NET extensions installed, .NET is automatically populating a bunch of files under `examples/DotNet Examples/TestMonitor/CreateResultsAndSteps/obj/`. If I then build that project I get more files in the `bin` directory. Those files pollute the git changes list when working on other directories. [They are build output](https://stackoverflow.com/questions/233081/whats-the-obj-directory-for-in-net) so should not be tracked by git.

# Implementation

Add `bin` and `obj` to the root `.gitignore` alongside other build-related directories. Obj

# Testing

Locally there are no longer any modified files after this change.