### PR TITLE
Add code owner for Web Apps directory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 * @fredvisser @adamarnesen @TJ-G
-
+/examples/Web\ Apps/ @fredvisser @adamarnesen @TJ-G @jattasNI
 /.snyk @chris468 @cameronwaterman @BKnight760 @rbell517 @jattasNI @prestwick


### PR DESCRIPTION
I would like to be a codeowner for the `examples/Web Apps` directory so I can approve contributions and enforce the policies we've established for our first examples. For now I'm adding myself in addition to the existing owners.