### PR TITLE
Workflow deploy fix

### DIFF
--- a/.github/workflows/webapp-deploy.yml
+++ b/.github/workflows/webapp-deploy.yml
@@ -258,8 +258,9 @@ jobs:
 
   package-deploy:
     if: |
-
-      needs.generate-combined-matrix.outputs.is-empty != 'true'
+        github.repository_owner == 'ni' &&
+        startsWith(github.ref, 'refs/heads/main') &&
+        needs.generate-combined-matrix.outputs.is-empty != 'true'
     needs: [build-node, build-blazor, cache-slcli, generate-combined-matrix]
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/webapp-deploy.yml
+++ b/.github/workflows/webapp-deploy.yml
@@ -258,14 +258,13 @@ jobs:
 
   package-deploy:
     if: |
-      always() &&
-      github.repository_owner == 'ni' && startsWith(github.ref, 'refs/heads/main') &&
-      !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
+
+      needs.generate-combined-matrix.outputs.is-empty != 'true'
     needs: [build-node, build-blazor, cache-slcli, generate-combined-matrix]
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        app_dir: ${{ fromJSON(needs.generate-node-matrix.outputs.matrix) }}
+        app_dir: ${{ fromJSON(needs.generate-combined-matrix.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
Changed the matrix strategy to depend on "generate-combined-matrix" job output (outputs the dirs of all Blazor and Node—React/Angular webApps).

On changes to Ni/main branch, the webapps should now successfully deploy to the SystemLink environment from the  GitHub actions workflow.
 