### PR TITLE
Fix webapp deploy workflow errors and warnings

### DIFF
--- a/.github/workflows/webapp-deploy.yml
+++ b/.github/workflows/webapp-deploy.yml
@@ -166,7 +166,7 @@ jobs:
           echo "APP_NAME=$APP_NAME" >> $GITHUB_ENV
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0
 
@@ -204,7 +204,7 @@ jobs:
       cache-key: slcli-homebrew
     steps:
       - name: Restore Homebrew cache
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: /home/linuxbrew/.linuxbrew
           key: brew-cache-${{ runner.os }}-slcli

--- a/.github/workflows/webapp-deploy.yml
+++ b/.github/workflows/webapp-deploy.yml
@@ -306,21 +306,21 @@ jobs:
 
       - name: Login to SystemLink
         run: |
-          slcli login --profile ghActions --url "${{ secrets.SL_API_URL }}" \
+          slcli login --profile ghActions --url "${{ vars.SL_API_URL }}" \
             --api-key "${{ secrets.SL_API_KEY }}" \
-            --web-url "${{ secrets.SL_WEBSITE_URL }}" \
-            --workspace "${{ secrets.SL_WORKSPACE }}"
+            --web-url "${{ vars.SL_WEBSITE_URL }}" \
+            --workspace "${{ vars.SL_WORKSPACE }}"
 
       - name: Deploy webapp to SystemLink
         working-directory: ${{ env.APP_DIR }}
         run: |
           pkg="${{ env.APP_NAME }}.nipkg"
           WEBAPP_NAME="${{ env.APP_NAME }}_PROD"
-          WEBAPP_ID=$(slcli webapp list --workspace "${{ secrets.SL_WORKSPACE }}" --filter "$WEBAPP_NAME" --format json | jq -r '.[0].id // empty')
+          WEBAPP_ID=$(slcli webapp list --workspace "${{ vars.SL_WORKSPACE }}" --filter "$WEBAPP_NAME" --format json | jq -r '.[0].id // empty')
 
           if [[ -z "$WEBAPP_ID" ]]; then
             echo "   * Webapp does not exist -- publishing new"
-            slcli webapp publish "$pkg" --name "$WEBAPP_NAME" --workspace "${{ secrets.SL_WORKSPACE }}"
+            slcli webapp publish "$pkg" --name "$WEBAPP_NAME" --workspace "${{ vars.SL_WORKSPACE }}"
           else
             echo "   * Webapp exists -- updating"
             slcli webapp publish "$pkg" --id "$WEBAPP_ID"

--- a/.github/workflows/webapp-deploy.yml
+++ b/.github/workflows/webapp-deploy.yml
@@ -143,7 +143,7 @@ jobs:
         uses: actions/upload-artifact@v6
         if:
           github.repository_owner == 'ni' && startsWith(github.ref,
-          'refs/heads/webapp-deploy-workflow-error')
+          'refs/heads/main')
         with:
           name: ${{ env.APP_NAME }}-build
           path: ${{ env.APP_DIR }}/build
@@ -190,7 +190,7 @@ jobs:
         uses: actions/upload-artifact@v6
         if:
           github.repository_owner == 'ni' && startsWith(github.ref,
-          'refs/heads/webapp-deploy-workflow-error')
+          'refs/heads/main')
         with:
           name: ${{ env.APP_NAME }}-build
           path: ${{ env.APP_DIR }}/build
@@ -198,7 +198,7 @@ jobs:
   cache-slcli:
     if:
       github.repository_owner == 'ni' && startsWith(github.ref,
-      'refs/heads/webapp-deploy-workflow-error')
+      'refs/heads/main')
     runs-on: ubuntu-latest
     outputs:
       cache-key: slcli-homebrew
@@ -259,7 +259,7 @@ jobs:
   package-deploy:
     if: |
         github.repository_owner == 'ni' &&
-        startsWith(github.ref, 'refs/heads/webapp-deploy-workflow-error') &&
+        startsWith(github.ref, 'refs/heads/main') &&
         needs.generate-combined-matrix.outputs.is-empty != 'true'
     needs: [build-node, build-blazor, cache-slcli, generate-combined-matrix]
     runs-on: ubuntu-latest

--- a/.github/workflows/webapp-deploy.yml
+++ b/.github/workflows/webapp-deploy.yml
@@ -143,7 +143,7 @@ jobs:
         uses: actions/upload-artifact@v6
         if:
           github.repository_owner == 'ni' && startsWith(github.ref,
-          'refs/heads/main')
+          'refs/heads/webapp-deploy-workflow-error')
         with:
           name: ${{ env.APP_NAME }}-build
           path: ${{ env.APP_DIR }}/build
@@ -190,7 +190,7 @@ jobs:
         uses: actions/upload-artifact@v6
         if:
           github.repository_owner == 'ni' && startsWith(github.ref,
-          'refs/heads/main')
+          'refs/heads/webapp-deploy-workflow-error')
         with:
           name: ${{ env.APP_NAME }}-build
           path: ${{ env.APP_DIR }}/build
@@ -198,7 +198,7 @@ jobs:
   cache-slcli:
     if:
       github.repository_owner == 'ni' && startsWith(github.ref,
-      'refs/heads/main')
+      'refs/heads/webapp-deploy-workflow-error')
     runs-on: ubuntu-latest
     outputs:
       cache-key: slcli-homebrew
@@ -259,7 +259,7 @@ jobs:
   package-deploy:
     if: |
         github.repository_owner == 'ni' &&
-        startsWith(github.ref, 'refs/heads/main') &&
+        startsWith(github.ref, 'refs/heads/webapp-deploy-workflow-error') &&
         needs.generate-combined-matrix.outputs.is-empty != 'true'
     needs: [build-node, build-blazor, cache-slcli, generate-combined-matrix]
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Rationale

I was seeing a couple issues with the new webapp deploy workflows:
1. errors accessing repo variables that specify environment and credentials
   - the workflow was attempting to access some variables as secrets
3. apps being deployed to BYU2026 workspace which most people don't have access to
   - updated to deploy to the Default workspace
5. deprecation warnings about old versions of workflow steps
   - updated versions to latest of workflows reporting warnings


I tested the changes by temporarily updating the workflow to deploy from this branch and verified that the webapps deploy to the correct workspace with no errors or warnings.