### PR TITLE
chore: enable SCA scanning

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 * @fredvisser @adamarnesen @TJ-G
 /examples/Web\ Apps/ @fredvisser @adamarnesen @TJ-G @jattasNI
 /.github @fredvisser @adamarnesen @TJ-G @jattasNI
-/.snyk @chris468 @cameronwaterman @BKnight760 @rbell517 @jattasNI @prestwick
-/.wiz @chris468 @cameronwaterman @BKnight760 @rbell517 @jattasNI @prestwick
+/.snyk @ni/security-scanning-owners
+/.wiz @ni/security-scanning-owners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,4 @@
 /examples/Web\ Apps/ @fredvisser @adamarnesen @TJ-G @jattasNI
 /.github @fredvisser @adamarnesen @TJ-G @jattasNI
 /.snyk @chris468 @cameronwaterman @BKnight760 @rbell517 @jattasNI @prestwick
+/.wiz @chris468 @cameronwaterman @BKnight760 @rbell517 @jattasNI @prestwick

--- a/.wiz
+++ b/.wiz
@@ -1,2 +1,9 @@
+# Wiz Code global path exclusions for this repository.
+#
+# NOTE: Both /* and /**/* patterns are required per directory due to a known
+# Wiz glob bug (WZ-81029) where /**/* does not match direct children of a
+# directory. The /* pattern catches direct children while /**/* catches nested
+# files. This duplication can be removed once the bug is fixed.
+
 ignore:
   global_paths: {}

--- a/.wiz
+++ b/.wiz
@@ -1,0 +1,2 @@
+ignore:
+  global_paths: {}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,7 +176,7 @@ The package will be automatically versioned, tagged, and published to PyPI.
 
 ## Security scanning
 
-See the [security scanning reference](https://dev.azure.com/ni/DevCentral/_wiki/wikis/Stratus/160265/Security-scanning-reference) for information on security scanning tools, workflows, and best practices.
+**Contributors within NI/Emerson**: See the [security scanning reference](https://dev.azure.com/ni/DevCentral/_wiki/wikis/Stratus/160265/Security-scanning-reference) for information on security scanning tools, workflows, and best practices.
 
 **Contributors outside of NI/Emerson**: If you are having issues resolving a vulnerability identified on your PR, consult with a code owner to understand your options for resolution.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,33 +174,11 @@ When commits following the conventional format are merged to `main` and affect:
 
 The package will be automatically versioned, tagged, and published to PyPI.
 
-## Security scanning with Snyk
+## Security scanning
 
-This repository uses [Snyk](https://snyk.io/) for security scanning to identify
-and fix vulnerabilities in code before they reach production. Snyk provides
-Static Application Security Testing (SAST) that scans your code for security
-issues as you develop.
+See the [security scanning reference](https://dev.azure.com/ni/DevCentral/_wiki/wikis/Stratus/160265/Security-scanning-reference) for information on security scanning tools, workflows, and best practices.
 
-- **IDE integration**: Install the Snyk extension for
-  [Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=snyk-security.snyk-vulnerability-scanner)
-  or
-  [Visual Studio](https://marketplace.visualstudio.com/items?itemName=snyk-security.snyk-vulnerability-scanner-vs-2022)
-  to get real-time security feedback while writing code. To suggest the Snyk
-  extension to contributors, add `.vscode/extensions.json` or `.vsconfig` files
-  to your project root. The VSCode Snyk extension has a richer feature set and
-  is the preferred IDE for working with Snyk.
-- **Pull request scanning**: Snyk automatically scans PRs and posts comments for
-  high/critical vulnerabilities.
-- **Post-merge monitoring**: Automated bugs are created for unresolved issues
-  after code is merged.
-
-**Contributors within NI/Emerson**: For detailed guidance on working with Snyk,
-including how to address security issues and create ignore records, see the
-[Snyk reference](https://dev.azure.com/ni/DevCentral/_wiki/wikis/Stratus/146862/Snyk-reference).
-
-**Contributors outside of NI/Emerson**: If you are having issues resolving a
-vulnerability Snyk identifies on your PR, consult with a code owner to
-understand your options for resolution.
+**Contributors outside of NI/Emerson**: If you are having issues resolving a vulnerability identified on your PR, consult with a code owner to understand your options for resolution.
 
 ## Developer Certificate of Origin (DCO)
 


### PR DESCRIPTION
- Add .wiz config file
- Created a team for the security scanning files
- Replaced security scanning section in the readme with a link to the handbook document, which already has the wiz content. The readme content was duplicated across multiple repos, we will have more updates, and the handbook provides a central location for those updates.